### PR TITLE
Replaced time.clock() by time.process_time()

### DIFF
--- a/pyrtree/bench/bench_libspatial.py
+++ b/pyrtree/bench/bench_libspatial.py
@@ -15,12 +15,12 @@ from rtree import Rtree
 if __name__ == "__main__":
     G = RectangleGen()
     idx = Rtree() # this is a libspatialindex one.
-    start = time.clock()
-    interval_start = time.clock()
+    start = time.process_time()
+    interval_start = time.process_time()
     for v in range(ITER):
         if 0 == (v % INTERVAL):
             # interval time taken, total time taken, # rects, cur max depth
-            t = time.clock()
+            t = time.process_time()
             
             dt = t - interval_start
             print("%d,%s,%f" % (v, "itime_t", dt))
@@ -28,7 +28,7 @@ if __name__ == "__main__":
             #print("%d,%s,%d" % (v, "max_depth", rt.node.max_depth()))
             #print("%d,%s,%d" % (v, "mean_depth", rt.node.mean_depth()))
 
-            interval_start = time.clock()
+            interval_start = time.process_time()
         rect = G.rect(0.000001)
         idx.add(v,rect.coords())
 

--- a/pyrtree/bench/bench_rtree.py
+++ b/pyrtree/bench/bench_rtree.py
@@ -25,12 +25,12 @@ if __name__ == "__main__":
     gc.disable() # FFFFUUUUUUUUUUU
     G = RectangleGen()
     rt = RTree()
-    start = time.clock()
-    interval_start = time.clock()
+    start = time.process_time()
+    interval_start = time.process_time()
     for v in range(ITER):
         if 0 == (v % INTERVAL):
             # interval time taken, total time taken, # rects, cur max depth
-            t = time.clock()
+            t = time.process_time()
             
             dt = t - interval_start
             print("%d,%s,%f" % (v, "itime_t", dt))
@@ -44,7 +44,7 @@ if __name__ == "__main__":
             #print("%d,%s,%d" % (v, "max_depth", rt.node.max_depth()))
             #print("%d,%s,%d" % (v, "mean_depth", rt.node.mean_depth()))
 
-            interval_start = time.clock()
+            interval_start = time.process_time()
         o = TstO(G.rect(0.000001))
         rt.insert(v,o.rect)
 

--- a/pyrtree/rtree.py
+++ b/pyrtree/rtree.py
@@ -238,7 +238,7 @@ class _NodeCursor(object):
             return
 
 
-        t = time.clock()
+        t = time.process_time()
         
         cur_score = -10
 
@@ -253,7 +253,7 @@ class _NodeCursor(object):
 
         self._set_children(nodes)
         
-        dur = (time.clock() - t)
+        dur = (time.process_time() - t)
         c = float(self.root.stats["overflow_f"]) 
         oa = self.root.stats["avg_overflow_t_f"]
         self.root.stats["avg_overflow_t_f"] = (dur / (c + 1.0)) + (c * oa / (c + 1.0))
@@ -370,7 +370,7 @@ def closest(centroids, node):
 
 
 def k_means_cluster(root, k, nodes):
-    t = time.clock()
+    t = time.process_time()
     if len(nodes) <= k: return [ [n] for n in nodes ]
     
     ns = list(nodes)
@@ -409,7 +409,7 @@ def k_means_cluster(root, k, nodes):
         new_cluster_centers = [ center_of_gravity(c) for c in clusters ]
         if new_cluster_centers == cluster_centers : 
             root.stats["avg_kmeans_iter_f"] = float(root.stats["sum_kmeans_iter_f"] / root.stats["count_kmeans_iter_f"])
-            root.stats["longest_kmeans"] = max(root.stats["longest_kmeans"], (time.clock() - t))
+            root.stats["longest_kmeans"] = max(root.stats["longest_kmeans"], (time.process_time() - t))
             return clusters
         else: cluster_centers = new_cluster_centers
         


### PR DESCRIPTION
time.clock() is deprecated since Python 3.3 and was removed in Python
3.8. It is recommended to use process_time() instead.